### PR TITLE
Make view button source of download

### DIFF
--- a/assets/scripts/templates/file_row.handlebars
+++ b/assets/scripts/templates/file_row.handlebars
@@ -5,11 +5,11 @@
     <td>{{upload.createdAt}}</td>
     <td>{{upload.updatedAt}}</td>
     <td><input class="file-tags file-table-cell-edit file-table-cell-inactive" value="{{upload.tags}}" disabled="disabled"></td>
-    
+
     <td><button type="button" class="btn-line clickable editable-btn edit-btn">Edit</button></td>
     <td><button type="button" class="btn-line clickable editable-btn update-btn hide">Update</button></td>
     <td><button type="button" class="btn-line clickable editable-btn delete-btn" data-toggle="modal" data-target="#deleteModal">Delete</button></td>
-    <td><button type="button" class="btn-line clickable view-btn"><a href="{{upload.url}}" target="_blank">View</a></button></td>
+    <td><button type="button" class="btn-line clickable view-btn" onclick="window.open('{{upload.url}}')">View</button></td>
 
   </tr>
   </form>


### PR DESCRIPTION
-In the previous version, the text inside of the "view" button was
the link that opened the new window with the download. As such,
if you didn't click directly on the link, but clicked on the button,
you would download nothing and get no response from the system.
-In this version, the 'a' has been removed and the button performs
the new tab/window open and download.